### PR TITLE
chore: mirror tetragon 1.6.1

### DIFF
--- a/mirrors.yaml
+++ b/mirrors.yaml
@@ -19,7 +19,7 @@ mirrors:
 
   - chart: tetragon
     repo: https://helm.cilium.io
-    version: "1.3.0"
+    version: "1.6.1"
 
   - chart: alloy
     repo: https://grafana.github.io/helm-charts


### PR DESCRIPTION
## Summary
- Bump mirrored tetragon chart 1.3.0 → 1.6.1 for homelab cluster upgrade.
- Motivations: ringbuf-default (lowers BPF ENOSPC drops — we're at 23M), Go 1.25 runtime, non-root operator, 18 months of stability fixes.
- CRD stays `cilium.io/v1alpha1`, `tetragon_policy_events_total` schema unchanged.

## Test plan
- [ ] CI mirror job publishes `tetragon:1.6.1` to `oci://ghcr.io/fredericrous/charts`.
- [ ] Homelab Flux reconciles `HelmRelease/tetragon` → `chartVersion: 1.6.1`.
- [ ] DaemonSet rolls; all 8 TracingPolicies reach `state=enabled`.
- [ ] Verify `tetragon_bpf_missed_events_total` rate drops after ringbuf switch.