### PR TITLE
chore: mirror tetragon 1.7.0

### DIFF
--- a/mirrors.yaml
+++ b/mirrors.yaml
@@ -19,7 +19,7 @@ mirrors:
 
   - chart: tetragon
     repo: https://helm.cilium.io
-    version: "1.6.1"
+    version: "1.7.0"
 
   - chart: alloy
     repo: https://grafana.github.io/helm-charts


### PR DESCRIPTION
## Summary
- Mirror upstream tetragon chart 1.7.0 (released 2026-04-29) for the homelab cluster.

Required to unblock the corresponding homelab HelmRelease bump in fredericrous/homelab (commits cce63e64 + 368bebb6 — Firefox sandbox-mount FP fix + chart bump, not yet pushed).

## Why 1.7.0
- Ships PR #4654 (cilium/tetragon) — narrow related matchBinaries fix for upstream issue #4641.
- Adds the new `matchParentBinaries` selector (PR #4254) referenced in the `detect-container-escape-mount` policy comment.
- Helm-value upgrade notes (server-address default localhost:54321 → unix socket): no override set in our HelmRelease, no-op for us.

The LSM-hook-scope matchBinaries gap is NOT explicitly fixed in 1.7.0 release notes, so the PromQL `unless` clauses on `TetragonContainerEscapeAttempt` remain load-bearing pending re-test after reconcile.

## Test plan
- [ ] Merge → mirror workflow runs → `helm pull tetragon 1.7.0` from helm.cilium.io succeeds
- [ ] `helm push` to oci://ghcr.io/fredericrous/charts succeeds
- [ ] `helm show chart oci://ghcr.io/fredericrous/charts/tetragon --version 1.7.0` returns the chart
- [ ] Homelab Flux HelmRelease reconciles 1.6.1 → 1.7.0 without error once homelab main is pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)