### PR TITLE
chore: update openauth to 0.0.1

### DIFF
--- a/charts/openauth/Chart.yaml
+++ b/charts/openauth/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: openauth
+description: |
+  OIDC issuer for the website-builder, separate from homelab Authelia.
+  Wraps @openauthjs/openauth with the password provider + default UI.
+  Single-pod v1; persists refresh tokens + password hashes to a PVC.
+type: application
+version: 0.0.1
+appVersion: 0.0.1
+maintainers:
+  - name: frederic.rous
+icon: https://github.githubassets.com/images/icons/emoji/lock_with_ink_pen.png

--- a/charts/openauth/templates/deployment.yaml
+++ b/charts/openauth/templates/deployment.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app.kubernetes.io/name: openauth
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  # Recreate strategy: with a RWO PVC + single replica, rolling update
+  # would deadlock on volume detach. Recreate has a tiny availability
+  # window (~5s) which is acceptable for an auth issuer.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: openauth
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: openauth
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: openauth
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.http.port }}
+              protocol: TCP
+          env:
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- if .Values.persistence.enabled }}
+          volumeMounts:
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath }}
+          {{- end }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+      {{- if .Values.persistence.enabled }}
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-data
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/openauth/templates/pvc.yaml
+++ b/charts/openauth/templates/pvc.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}-data
+  labels:
+    app.kubernetes.io/name: openauth
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+{{- end }}

--- a/charts/openauth/templates/service.yaml
+++ b/charts/openauth/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app.kubernetes.io/name: openauth
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  selector:
+    app.kubernetes.io/name: openauth
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+    - name: http
+      port: {{ .Values.http.port }}
+      targetPort: http
+      protocol: TCP

--- a/charts/openauth/values.yaml
+++ b/charts/openauth/values.yaml
@@ -1,0 +1,59 @@
+image:
+  repository: ghcr.io/fredericrous/openauth
+  tag: "" # set by release workflow / values override
+  pullPolicy: IfNotPresent
+
+replicaCount: 1 # v1 single-pod; MemoryStorage state is persisted to a PVC
+
+http:
+  port: 3000
+
+env:
+  OPENAUTH_PORT: "3000"
+  OPENAUTH_PERSIST_PATH: "/data/openauth.json"
+  # Set to smtp://relay.dkim-manager.svc.cluster.local.:25 to wire the
+  # homelab SMTP relay for password-reset emails. Empty = codes logged
+  # to stdout (acceptable for early access; users can be reset manually).
+  OPENAUTH_SMTP_URL: ""
+
+persistence:
+  enabled: true
+  size: 1Gi
+  storageClass: "" # use the cluster default (or set explicitly)
+  accessMode: ReadWriteOnce
+  mountPath: /data
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
+
+livenessProbe:
+  httpGet:
+    path: /.well-known/openid-configuration
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 30
+readinessProbe:
+  httpGet:
+    path: /.well-known/openid-configuration
+    port: http
+  initialDelaySeconds: 2
+  periodSeconds: 10
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroup: 1000
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+  readOnlyRootFilesystem: true
+
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
## Automated Chart Update

Source: `fredericrous/website-builder` `apps/openauth/chart/openauth` → `charts/openauth/`

- **Chart version**: `0.0.1` (chart and app synced)
- **Release notes**: https://github.com/fredericrous/website-builder/releases/tag/openauth-v0.0.1