### PR TITLE
chore: update openauth to 0.0.2

### DIFF
--- a/charts/openauth/Chart.yaml
+++ b/charts/openauth/Chart.yaml
@@ -5,8 +5,8 @@ description: |
   Wraps @openauthjs/openauth with the password provider + default UI.
   Single-pod v1; persists refresh tokens + password hashes to a PVC.
 type: application
-version: 0.0.1
-appVersion: 0.0.1
+version: 0.0.2
+appVersion: 0.0.2
 maintainers:
   - name: frederic.rous
 icon: https://github.githubassets.com/images/icons/emoji/lock_with_ink_pen.png


### PR DESCRIPTION
## Automated Chart Update

Source: `fredericrous/website-builder` `apps/openauth/chart/openauth` → `charts/openauth/`

- **Chart version**: `0.0.2` (chart and app synced)
- **Release notes**: https://github.com/fredericrous/website-builder/releases/tag/openauth-v0.0.2