### PR TITLE
chore: update openauth to 0.0.2

### DIFF
--- a/charts/openauth/Chart.yaml
+++ b/charts/openauth/Chart.yaml
@@ -1,9 +1,6 @@
 apiVersion: v2
 name: openauth
-description: |
-  OIDC issuer for the website-builder, separate from homelab Authelia.
-  Wraps @openauthjs/openauth with the password provider + default UI.
-  Single-pod v1; persists refresh tokens + password hashes to a PVC.
+description: OIDC issuer for the website-builder (wraps @openauthjs/openauth)
 type: application
 version: 0.0.2
 appVersion: 0.0.2


### PR DESCRIPTION
## Automated Chart Update

Source: `fredericrous/website-builder` `apps/openauth/chart/openauth` → `charts/openauth/`

- **Chart version**: `0.0.2` (chart and app synced)
- **Release notes**: https://github.com/fredericrous/website-builder/releases/tag/openauth-v0.0.2