### PR TITLE
chore: update openauth to 0.0.3

### DIFF
--- a/charts/openauth/Chart.yaml
+++ b/charts/openauth/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: openauth
 description: OIDC issuer for the website-builder (wraps @openauthjs/openauth)
 type: application
-version: 0.0.2
-appVersion: 0.0.2
+version: 0.0.3
+appVersion: 0.0.3
 maintainers:
   - name: frederic.rous
 icon: https://github.githubassets.com/images/icons/emoji/lock_with_ink_pen.png


### PR DESCRIPTION
## Automated Chart Update

Source: `fredericrous/website-builder` `apps/openauth/chart/openauth` → `charts/openauth/`

- **Chart version**: `0.0.3` (chart and app synced)
- **Release notes**: https://github.com/fredericrous/website-builder/releases/tag/openauth-v0.0.3