### PR TITLE
chore: update builder-api to 0.0.1

### DIFF
--- a/charts/builder-api/Chart.yaml
+++ b/charts/builder-api/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: builder-api
+description: website-builder backend API (createSite, listMySites, getSite, publishCanned)
+type: application
+version: 0.0.1
+appVersion: 0.0.1
+maintainers:
+  - name: frederic.rous
+icon: https://github.githubassets.com/images/icons/emoji/electric_plug.png

--- a/charts/builder-api/templates/deployment.yaml
+++ b/charts/builder-api/templates/deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app.kubernetes.io/name: builder-api
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: builder-api
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: builder-api
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: builder-api
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.http.port }}
+              protocol: TCP
+          env:
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/builder-api/templates/service.yaml
+++ b/charts/builder-api/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app.kubernetes.io/name: builder-api
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  selector:
+    app.kubernetes.io/name: builder-api
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+    - name: http
+      port: {{ .Values.http.port }}
+      targetPort: http
+      protocol: TCP

--- a/charts/builder-api/values.yaml
+++ b/charts/builder-api/values.yaml
@@ -1,0 +1,50 @@
+image:
+  repository: ghcr.io/fredericrous/builder-api
+  tag: ""
+  pullPolicy: IfNotPresent
+
+replicaCount: 1
+
+http:
+  port: 4000
+
+env:
+  BUILDER_API_PORT: "4000"
+  # DATABASE_URL, OIDC_*, S3_*, BUILDER_PUBLIC_HOST come from the
+  # HelmRelease postRenderer in homelab (Vault + reflected secrets +
+  # inline configs).
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 30
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  initialDelaySeconds: 2
+  periodSeconds: 10
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroup: 1000
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+  readOnlyRootFilesystem: false
+
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
## Automated Chart Update

Source: `fredericrous/website-builder` `apps/builder-api/chart/builder-api` → `charts/builder-api/`

- **Chart version**: `0.0.1` (chart and app synced)
- **Release notes**: https://github.com/fredericrous/website-builder/releases/tag/builder-api-v0.0.1