### PR TITLE
chore: update sync-bridge to 0.0.1

### DIFF
--- a/charts/sync-bridge/Chart.yaml
+++ b/charts/sync-bridge/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: sync-bridge
+description: |
+  Node service that bridges browser WebSocket clients to Hyperswarm
+  for Yjs document sync in the website-builder.
+
+  Single-pod for v1 (per PLAN.md "v1 scaling posture"). The Hyperswarm
+  DHT layer requires UDP egress for hole-punching, so production
+  deployments use `hostNetwork: true` or a NodePort with UDP forwarding
+  — see values.yaml.
+type: application
+version: 0.0.1
+appVersion: "0.0.1"
+maintainers:
+  - name: frederic.rous
+icon: https://github.githubassets.com/images/icons/emoji/satellite.png

--- a/charts/sync-bridge/templates/deployment.yaml
+++ b/charts/sync-bridge/templates/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app.kubernetes.io/name: sync-bridge
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: sync-bridge
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: sync-bridge
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      hostNetwork: {{ .Values.hostNetwork }}
+      {{- if .Values.hostNetwork }}
+      # When hostNetwork is true the pod inherits the node's DNS;
+      # explicit ClusterFirstWithHostNet keeps in-cluster name
+      # resolution working.
+      dnsPolicy: ClusterFirstWithHostNet
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: sync-bridge
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: ws
+              containerPort: {{ .Values.ws.port }}
+              protocol: TCP
+            - name: admin
+              containerPort: {{ .Values.admin.port }}
+              protocol: TCP
+          env:
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/sync-bridge/templates/service.yaml
+++ b/charts/sync-bridge/templates/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app.kubernetes.io/name: sync-bridge
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  selector:
+    app.kubernetes.io/name: sync-bridge
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+    # WebSocket TCP — fronted by the istio HTTPRoute /
+    # envoyfilter-coop-coep stack (T1.6).
+    - name: ws
+      port: {{ .Values.ws.port }}
+      targetPort: ws
+      protocol: TCP
+    # Admin TCP — scraped by Prometheus. Not exposed via istio.
+    - name: admin
+      port: {{ .Values.admin.port }}
+      targetPort: admin
+      protocol: TCP

--- a/charts/sync-bridge/values.yaml
+++ b/charts/sync-bridge/values.yaml
@@ -1,0 +1,76 @@
+image:
+  repository: ghcr.io/fredericrous/sync-bridge
+  tag: "" # set by release workflow
+  pullPolicy: IfNotPresent
+
+replicaCount: 1 # single-pod for v1 per PLAN.md scaling posture
+
+# UDP / Hyperswarm requirements
+#   The DHT does UDP hole-punching, so a plain ClusterIP isn't enough.
+#   Two production patterns work:
+#     (a) hostNetwork: true on the pod, run on a node with a routable
+#         public/LAN IP. Simplest, but pins the pod to one node.
+#     (b) Service type NodePort with UDP forwarding + envoy/istio
+#         passthrough in front. More moving parts, but lets you keep
+#         the pod schedulable.
+#   v1 picks (a). When moving to multi-pod for v2, switch to (b) plus
+#   topic-affinity routing per S7 REPORT § "Bridge HA / horizontal scaling".
+hostNetwork: true
+
+# Ports
+ws:
+  port: 3010
+admin:
+  port: 3011
+
+# Env config — driven by environment in production
+env:
+  SYNC_BRIDGE_PORT: "3010"
+  SYNC_BRIDGE_ADMIN_PORT: "3011"
+  SYNC_BRIDGE_MAX_MSG_BYTES: "1000000"
+  SYNC_BRIDGE_MSGS_PER_SEC: "100"
+  # Auth — production REQUIRES these. The chart should fail to install
+  # without them; templates/_helpers.tpl asserts.
+  SYNC_BRIDGE_AUTH_JWKS_URL: "https://auth.builder.example.com/.well-known/jwks.json"
+  SYNC_BRIDGE_AUTH_ISSUER: "https://auth.builder.example.com"
+  SYNC_BRIDGE_AUTH_AUDIENCE: "sync-bridge"
+  # Bootstrap is optional — empty = public Hyperswarm DHT
+  SYNC_BRIDGE_BOOTSTRAP: ""
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 1
+    memory: 512Mi
+
+# Liveness checks /healthz on the admin port. Readiness same — once
+# the bridge is listening it's ready (no migration / warmup phase).
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: admin
+  initialDelaySeconds: 5
+  periodSeconds: 30
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: admin
+  initialDelaySeconds: 2
+  periodSeconds: 10
+
+# Pod security
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroup: 1000
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+  readOnlyRootFilesystem: true
+
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
## Automated Chart Update

Source: `fredericrous/website-builder` `apps/sync-bridge/chart/sync-bridge` → `charts/sync-bridge/`

- **Chart version**: `0.0.1` (chart and app synced)
- **Release notes**: https://github.com/fredericrous/website-builder/releases/tag/sync-bridge-v0.0.1