### PR TITLE
chore: update sync-bridge to 0.0.1

### DIFF
--- a/charts/sync-bridge/values.yaml
+++ b/charts/sync-bridge/values.yaml
@@ -1,9 +1,9 @@
 image:
   repository: ghcr.io/fredericrous/sync-bridge
-  tag: "" # set by release workflow
+  tag: ""  # set by release workflow
   pullPolicy: IfNotPresent
 
-replicaCount: 1 # single-pod for v1 per PLAN.md scaling posture
+replicaCount: 1  # single-pod for v1 per PLAN.md scaling posture
 
 # UDP / Hyperswarm requirements
 #   The DHT does UDP hole-punching, so a plain ClusterIP isn't enough.


### PR DESCRIPTION
## Automated Chart Update

Source: `fredericrous/website-builder` `apps/sync-bridge/chart/sync-bridge` → `charts/sync-bridge/`

- **Chart version**: `0.0.1` (chart and app synced)
- **Release notes**: https://github.com/fredericrous/website-builder/releases/tag/sync-bridge-v0.0.1