### PR TITLE
chore: update sync-bridge to 0.0.2

### DIFF
--- a/charts/sync-bridge/Chart.yaml
+++ b/charts/sync-bridge/Chart.yaml
@@ -9,8 +9,8 @@ description: |
   deployments use `hostNetwork: true` or a NodePort with UDP forwarding
   — see values.yaml.
 type: application
-version: 0.0.1
-appVersion: "0.0.1"
+version: 0.0.2
+appVersion: 0.0.2
 maintainers:
   - name: frederic.rous
 icon: https://github.githubassets.com/images/icons/emoji/satellite.png

--- a/charts/sync-bridge/values.yaml
+++ b/charts/sync-bridge/values.yaml
@@ -1,9 +1,9 @@
 image:
   repository: ghcr.io/fredericrous/sync-bridge
-  tag: ""  # set by release workflow
+  tag: "" # set by release workflow
   pullPolicy: IfNotPresent
 
-replicaCount: 1  # single-pod for v1 per PLAN.md scaling posture
+replicaCount: 1 # single-pod for v1 per PLAN.md scaling posture
 
 # UDP / Hyperswarm requirements
 #   The DHT does UDP hole-punching, so a plain ClusterIP isn't enough.


### PR DESCRIPTION
## Automated Chart Update

Source: `fredericrous/website-builder` `apps/sync-bridge/chart/sync-bridge` → `charts/sync-bridge/`

- **Chart version**: `0.0.2` (chart and app synced)
- **Release notes**: https://github.com/fredericrous/website-builder/releases/tag/sync-bridge-v0.0.2