### PR TITLE
chore: update builder-webapp to 0.0.18

### DIFF
--- a/charts/builder-webapp/Chart.yaml
+++ b/charts/builder-webapp/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: builder-webapp
 description: website-builder SPA + auth backend (openauth client + session cookie)
 type: application
-version: 0.0.17
-appVersion: 0.0.17
+version: 0.0.18
+appVersion: 0.0.18
 maintainers:
   - name: frederic.rous
 icon: https://github.githubassets.com/images/icons/emoji/sparkles.png


### PR DESCRIPTION
## Automated Chart Update

Source: `fredericrous/website-builder` `apps/builder-webapp/chart/builder-webapp` → `charts/builder-webapp/`

- **Chart version**: `0.0.18` (chart and app synced)
- **Release notes**: https://github.com/fredericrous/website-builder/releases/tag/builder-webapp-v0.0.18