### PR TITLE
chore: update sync-bridge to 0.0.5

### DIFF
--- a/charts/sync-bridge/Chart.yaml
+++ b/charts/sync-bridge/Chart.yaml
@@ -9,8 +9,8 @@ description: |
   deployments use `hostNetwork: true` or a NodePort with UDP forwarding
   — see values.yaml.
 type: application
-version: 0.0.4
-appVersion: 0.0.4
+version: 0.0.5
+appVersion: 0.0.5
 maintainers:
   - name: frederic.rous
 icon: https://github.githubassets.com/images/icons/emoji/satellite.png


### PR DESCRIPTION
## Automated Chart Update

Source: `fredericrous/website-builder` `apps/sync-bridge/chart/sync-bridge` → `charts/sync-bridge/`

- **Chart version**: `0.0.5` (chart and app synced)
- **Release notes**: https://github.com/fredericrous/website-builder/releases/tag/sync-bridge-v0.0.5