### PR TITLE
chore: update builder-api to 0.0.4

### DIFF
--- a/charts/builder-api/Chart.yaml
+++ b/charts/builder-api/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: builder-api
 description: website-builder backend API (createSite, listMySites, getSite, publishCanned)
 type: application
-version: 0.0.3
-appVersion: 0.0.3
+version: 0.0.4
+appVersion: 0.0.4
 maintainers:
   - name: frederic.rous
 icon: https://github.githubassets.com/images/icons/emoji/electric_plug.png

--- a/charts/builder-api/templates/deployment.yaml
+++ b/charts/builder-api/templates/deployment.yaml
@@ -32,6 +32,16 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.internalCA.enabled }}
+          volumeMounts:
+            - name: internal-ca
+              mountPath: /certs
+              readOnly: true
+          {{- end }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
@@ -40,6 +50,16 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+      {{- if .Values.internalCA.enabled }}
+      volumes:
+        - name: internal-ca
+          secret:
+            secretName: {{ .Values.internalCA.secretName }}
+            items:
+              - key: {{ .Values.internalCA.key | default "ca.crt" }}
+                path: ca.crt
+            optional: true
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/builder-api/values.yaml
+++ b/charts/builder-api/values.yaml
@@ -12,7 +12,24 @@ env:
   BUILDER_API_PORT: "4000"
   # DATABASE_URL, OIDC_*, S3_*, BUILDER_PUBLIC_HOST come from the
   # HelmRelease postRenderer in homelab (Vault + reflected secrets +
-  # inline configs).
+  # inline configs). SMTP_HOST/PORT/USER/FROM also come from the
+  # HelmRelease envs; SMTP_PASS is injected via envFrom referencing
+  # an ExternalSecret-backed Secret (so it never lives in plaintext
+  # YAML).
+
+# Extra envs from Secrets / ConfigMaps. Used by homelab to inject
+# SMTP_PASS via an ExternalSecret-backed Secret. Empty list in the
+# chart default — every entry has to come from the consumer.
+envFrom: []
+
+# Mounts the homelab's internal CA cert at /certs/ca.crt so the SMTP
+# transport can verify stalwart's TLS without disabling cert checks.
+# Disabled by default; homelab enables + reflects vault-internal-ca
+# into the builder namespace via internal-ca-reflector.yaml.
+internalCA:
+  enabled: false
+  secretName: vault-internal-ca
+  key: tls.crt
 
 resources:
   requests:


### PR DESCRIPTION
## Automated Chart Update

Source: `fredericrous/website-builder` `apps/builder-api/chart/builder-api` → `charts/builder-api/`

- **Chart version**: `0.0.4` (chart and app synced)
- **Release notes**: https://github.com/fredericrous/website-builder/releases/tag/builder-api-v0.0.4