### PR TITLE
chore: update builder-api to 0.0.5

### DIFF
--- a/charts/builder-api/Chart.yaml
+++ b/charts/builder-api/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: builder-api
 description: website-builder backend API (createSite, listMySites, getSite, publishCanned)
 type: application
-version: 0.0.4
-appVersion: 0.0.4
+version: 0.0.5
+appVersion: 0.0.5
 maintainers:
   - name: frederic.rous
 icon: https://github.githubassets.com/images/icons/emoji/electric_plug.png


### PR DESCRIPTION
## Automated Chart Update

Source: `fredericrous/website-builder` `apps/builder-api/chart/builder-api` → `charts/builder-api/`

- **Chart version**: `0.0.5` (chart and app synced)
- **Release notes**: https://github.com/fredericrous/website-builder/releases/tag/builder-api-v0.0.5