### PR TITLE
chore: update workerd-runtime to 0.0.2

### DIFF
--- a/charts/workerd-runtime/Chart.yaml
+++ b/charts/workerd-runtime/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: workerd-runtime
 description: serves materialised HTML from garage, slug→site_id from Postgres
 type: application
-version: 0.0.1
-appVersion: 0.0.1
+version: 0.0.2
+appVersion: 0.0.2
 maintainers:
   - name: frederic.rous
 icon: https://github.githubassets.com/images/icons/emoji/satellite_antenna.png

--- a/charts/workerd-runtime/values.yaml
+++ b/charts/workerd-runtime/values.yaml
@@ -35,13 +35,21 @@ readinessProbe:
   periodSeconds: 10
 
 podSecurityContext:
+  # 65532 = the nonroot UID baked into gcr.io/distroless/nodejs24:nonroot.
+  # If you switch back to the alpine Dockerfile (which creates UID 1000),
+  # update these to 1000. Don't override at HelmRelease values — the
+  # numbers must match what the image actually has, or the kubelet
+  # SecurityContext check fails container start.
   runAsNonRoot: true
-  runAsUser: 1000
-  fsGroup: 1000
+  runAsUser: 65532
+  fsGroup: 65532
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:
     drop: ["ALL"]
+  # Distroless filesystem is read-only-safe; flip on once we confirm
+  # nothing writes to /app at runtime. Currently false to avoid
+  # surprises with /tmp usage by node modules.
   readOnlyRootFilesystem: false
 
 nodeSelector: {}


### PR DESCRIPTION
## Automated Chart Update

Source: `fredericrous/website-builder` `apps/workerd-runtime/chart/workerd-runtime` → `charts/workerd-runtime/`

- **Chart version**: `0.0.2` (chart and app synced)
- **Release notes**: https://github.com/fredericrous/website-builder/releases/tag/workerd-runtime-v0.0.2