### PR TITLE
chore: update workerd-runtime to 0.0.4

### DIFF
--- a/charts/workerd-runtime/Chart.yaml
+++ b/charts/workerd-runtime/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: workerd-runtime
 description: serves materialised HTML from garage, slug→site_id from Postgres
 type: application
-version: 0.0.3
-appVersion: 0.0.3
+version: 0.0.4
+appVersion: 0.0.4
 maintainers:
   - name: frederic.rous
 icon: https://github.githubassets.com/images/icons/emoji/satellite_antenna.png


### PR DESCRIPTION
## Automated Chart Update

Source: `fredericrous/website-builder` `apps/workerd-runtime/chart/workerd-runtime` → `charts/workerd-runtime/`

- **Chart version**: `0.0.4` (chart and app synced)
- **Release notes**: https://github.com/fredericrous/website-builder/releases/tag/workerd-runtime-v0.0.4