### PR TITLE
chore: update social-planner to 0.1.0

### DIFF
--- a/charts/social-planner/Chart.yaml
+++ b/charts/social-planner/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: social-planner
+description: Self-hosted social content planner (recommendation + week planner)
+type: application
+version: 0.1.0
+appVersion: 0.1.0
+home: https://github.com/fredericrous/social-planner
+sources:
+  - https://github.com/fredericrous/social-planner
+maintainers:
+  - name: fredericrous
+    url: https://github.com/fredericrous
+keywords:
+  - social
+  - planner
+  - homelab

--- a/charts/social-planner/templates/_helpers.tpl
+++ b/charts/social-planner/templates/_helpers.tpl
@@ -1,0 +1,28 @@
+{{- define "social-planner.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "social-planner.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "social-planner.labels" -}}
+app.kubernetes.io/name: {{ include "social-planner.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end -}}
+
+{{- define "social-planner.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "social-planner.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "social-planner.image" -}}
+{{- printf "%s:%s" .Values.image.repository (.Values.image.tag | default .Chart.AppVersion) -}}
+{{- end -}}

--- a/charts/social-planner/templates/deployment-worker.yaml
+++ b/charts/social-planner/templates/deployment-worker.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.worker.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "social-planner.fullname" . }}-worker
+  labels:
+    {{- include "social-planner.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "social-planner.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: worker
+  template:
+    metadata:
+      labels:
+        {{- include "social-planner.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: worker
+    spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: worker
+          image: {{ include "social-planner.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          command: {{ toJson .Values.worker.command }}
+          env:
+            {{- range $k, $v := .Values.env }}
+            - name: {{ $k }}
+              value: {{ $v | quote }}
+            {{- end }}
+          {{- if .Values.envFromSecret }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.envFromSecret }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.worker.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+{{- end }}

--- a/charts/social-planner/templates/deployment.yaml
+++ b/charts/social-planner/templates/deployment.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "social-planner.fullname" . }}
+  labels:
+    {{- include "social-planner.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "social-planner.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "social-planner.selectorLabels" . | nindent 8 }}
+    spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: web
+          image: {{ include "social-planner.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.web.port }}
+          env:
+            {{- range $k, $v := .Values.env }}
+            - name: {{ $k }}
+              value: {{ $v | quote }}
+            {{- end }}
+          {{- if .Values.envFromSecret }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.envFromSecret }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.web.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/charts/social-planner/templates/service.yaml
+++ b/charts/social-planner/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "social-planner.fullname" . }}
+  labels:
+    {{- include "social-planner.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "social-planner.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP

--- a/charts/social-planner/values.yaml
+++ b/charts/social-planner/values.yaml
@@ -1,0 +1,57 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/fredericrous/social-planner
+  # tag defaults to .Chart.AppVersion when empty
+  tag: ""
+  pullPolicy: IfNotPresent
+
+podSecurityContext:
+  fsGroup: 1001
+
+securityContext:
+  runAsUser: 1001
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: ["ALL"]
+
+service:
+  type: ClusterIP
+  port: 3000
+
+# Non-secret env (public config). Secret env (DATABASE_URL, ANTHROPIC_API_KEY) is supplied
+# via `envFromSecret` — a Secret created by the homelab ExternalSecret.
+env:
+  NODE_ENV: "production"
+  APP_NAME: "Social Planner"
+  ALLOWED_ORIGIN_SUFFIX: "daddyshome.fr"
+  TZ: "Europe/Paris"
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://alloy.monitoring.svc.cluster.local.:4318"
+
+# Name of a Secret whose keys (DATABASE_URL, ANTHROPIC_API_KEY, …) are loaded via envFrom.
+# Empty string disables envFrom (e.g. local `helm template`).
+envFromSecret: "social-planner-secrets"
+
+web:
+  port: 3000
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+# Worker is added in T6 (feed ingestion / scoring / dry-run scheduler). Off until then.
+worker:
+  enabled: false
+  command: ["node", "./build/worker/worker.js"]
+  resources:
+    requests:
+      cpu: 20m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi


### PR DESCRIPTION
## Automated Chart Update

Updates the `social-planner` chart to
`0.1.0` (chart and app synced).

See [release notes](https://github.com/fredericrous/social-planner/releases/tag/v0.1.0).