### PR TITLE
chore: update builder-api to 0.0.8

### DIFF
--- a/charts/builder-api/Chart.yaml
+++ b/charts/builder-api/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: builder-api
 description: website-builder backend API (createSite, listMySites, getSite, publishCanned)
 type: application
-version: 0.0.7
-appVersion: 0.0.7
+version: 0.0.8
+appVersion: 0.0.8
 maintainers:
   - name: frederic.rous
 icon: https://github.githubassets.com/images/icons/emoji/electric_plug.png

--- a/charts/builder-api/templates/deployment.yaml
+++ b/charts/builder-api/templates/deployment.yaml
@@ -27,6 +27,9 @@ spec:
             - name: http
               containerPort: {{ .Values.http.port }}
               protocol: TCP
+            - name: metrics
+              containerPort: {{ .Values.metrics.port }}
+              protocol: TCP
           env:
             {{- range $key, $value := .Values.env }}
             - name: {{ $key }}

--- a/charts/builder-api/templates/service.yaml
+++ b/charts/builder-api/templates/service.yaml
@@ -14,3 +14,7 @@ spec:
       port: {{ .Values.http.port }}
       targetPort: http
       protocol: TCP
+    - name: metrics
+      port: {{ .Values.metrics.port }}
+      targetPort: metrics
+      protocol: TCP

--- a/charts/builder-api/values.yaml
+++ b/charts/builder-api/values.yaml
@@ -8,8 +8,14 @@ replicaCount: 1
 http:
   port: 4000
 
+# Prometheus /metrics on a dedicated port (M5/S4). Scraped in-cluster by
+# the ServiceMonitor; never on the public api HTTPRoute.
+metrics:
+  port: 9090
+
 env:
   BUILDER_API_PORT: "4000"
+  METRICS_PORT: "9090"
   # DATABASE_URL, OIDC_*, S3_*, BUILDER_PUBLIC_HOST come from the
   # HelmRelease postRenderer in homelab (Vault + reflected secrets +
   # inline configs). SMTP_HOST/PORT/USER/FROM also come from the


### PR DESCRIPTION
## Automated Chart Update

Source: `fredericrous/website-builder` `apps/builder-api/chart/builder-api` → `charts/builder-api/`

- **Chart version**: `0.0.8` (chart and app synced)
- **Release notes**: https://github.com/fredericrous/website-builder/releases/tag/builder-api-v0.0.8