### PR TITLE
chore: update builder-admin to 0.0.1

### DIFF
--- a/charts/builder-admin/Chart.yaml
+++ b/charts/builder-admin/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: builder-admin
+description: website-builder internal ops console (Authelia-gated admin BFF + SPA)
+type: application
+version: 0.0.1
+appVersion: 0.0.1
+maintainers:
+  - name: frederic.rous
+icon: https://github.githubassets.com/images/icons/emoji/gear.png

--- a/charts/builder-admin/templates/deployment.yaml
+++ b/charts/builder-admin/templates/deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app.kubernetes.io/name: builder-admin
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: builder-admin
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: builder-admin
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: builder-admin
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.http.port }}
+              protocol: TCP
+          env:
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/builder-admin/templates/service.yaml
+++ b/charts/builder-admin/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app.kubernetes.io/name: builder-admin
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  selector:
+    app.kubernetes.io/name: builder-admin
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+    - name: http
+      port: {{ .Values.http.port }}
+      targetPort: http
+      protocol: TCP

--- a/charts/builder-admin/values.yaml
+++ b/charts/builder-admin/values.yaml
@@ -1,0 +1,55 @@
+image:
+  repository: ghcr.io/fredericrous/builder-admin
+  # Set by the release workflow / values override.
+  tag: ""
+  pullPolicy: IfNotPresent
+
+# Stateless read-mostly BFF + SPA. Single replica is plenty for an
+# internal console; the trust boundary is the gateway ext-auth + the
+# app's group check, not replica count.
+replicaCount: 1
+
+http:
+  # Must match httproute-admin.yaml's backendRef port (the Service
+  # exposes this; the container listens on PORT below).
+  port: 3000
+
+env:
+  PORT: "3000"
+  # ADMIN_GROUP + DATABASE_URL come from the HelmRelease (postRenderer)
+  # in homelab so the DB password isn't in values.yaml.
+
+resources:
+  requests:
+    cpu: 25m
+    memory: 96Mi
+  limits:
+    cpu: 300m
+    memory: 384Mi
+
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 30
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  initialDelaySeconds: 2
+  periodSeconds: 10
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroup: 1000
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+  readOnlyRootFilesystem: false
+
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
## Automated Chart Update

Source: `fredericrous/website-builder` `apps/builder-admin/chart/builder-admin` → `charts/builder-admin/`

- **Chart version**: `0.0.1` (chart and app synced)
- **Release notes**: https://github.com/fredericrous/website-builder/releases/tag/builder-admin-v0.0.1