### PR TITLE
feat: add customer-vision chart 0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ helm repo update
 | [kb-vision](charts/kb-vision/) | 0.12.6 | 0.12.6 | Knowledge Base for Homelab |
 | [duro-app](charts/duro-app/) | 1.50.52 | 1.50.52 | A household management dashboard with invite system |
 | [cluster-vision](charts/cluster-vision/) | 0.22.0 | 0.22.0 | Auto-generated infrastructure diagrams from live Kubernetes state |
+| [customer-vision](charts/customer-vision/) | 0.1.0 | 0.1.0 | CRM for the intelligent-enterprise suite — accounts, contacts, deals |
 | [ticket-vision](charts/ticket-vision/) | 0.8.0 | 0.8.0 | Fully automated ITSM for homelab |
 | [homelab-preview-operator](charts/homelab-preview-operator/) | 0.7.5 | 0.7.5 | A Kubernetes operator that automatically configures preview environments for applications |
 | [vault-transit-unseal-operator](charts/vault-transit-unseal-operator/) | 2.6.2 | 2.6.2 | A Kubernetes operator that automatically manages HashiCorp Vault initialization and unsealing using transit unseal |

--- a/charts/customer-vision/Chart.yaml
+++ b/charts/customer-vision/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: customer-vision
+description: CRM for the intelligent-enterprise suite — accounts, contacts, deals
+type: application
+version: 0.1.0
+appVersion: 0.1.0

--- a/charts/customer-vision/templates/pvc.yaml
+++ b/charts/customer-vision/templates/pvc.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+{{- end }}

--- a/charts/customer-vision/templates/rbac.yaml
+++ b/charts/customer-vision/templates/rbac.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-worker
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-lease
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "create", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-lease
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-worker
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-lease

--- a/charts/customer-vision/templates/service.yaml
+++ b/charts/customer-vision/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.web.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/component: web

--- a/charts/customer-vision/templates/web-deployment.yaml
+++ b/charts/customer-vision/templates/web-deployment.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-web
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/component: web
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Chart.Name }}
+      app.kubernetes.io/component: web
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Chart.Name }}
+        app.kubernetes.io/component: web
+    spec:
+      containers:
+        - name: web
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["npx", "react-router-serve", "./build/server/index.js"]
+          ports:
+            - containerPort: {{ .Values.web.port }}
+              name: http
+          envFrom:
+            - secretRef:
+                name: {{ .Release.Name }}-env
+          env:
+            - name: CV_DB_PATH
+              value: /db/customer-vision.sqlite
+            - name: OTEL_SERVICE_NAME
+              value: customer-vision-web
+          volumeMounts:
+            - name: data
+              mountPath: /db
+          resources:
+            {{- toYaml .Values.web.resources | nindent 12 }}
+          # Startup: give up to 2 minutes for migrations to complete
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 12
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+            # /health pings DB; allow a few transient failures before
+            # dropping the pod from Service endpoints.
+            failureThreshold: 3
+          # Liveness on /health/live (cheap, process-only) so a transient
+          # postgres blip drops the pod from the Service via readiness
+          # without also tripping liveness and restarting it in a loop.
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: http
+            periodSeconds: 30
+      volumes:
+        - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-data
+          {{- else }}
+          emptyDir: {}
+          {{- end }}

--- a/charts/customer-vision/templates/worker-deployment.yaml
+++ b/charts/customer-vision/templates/worker-deployment.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-worker
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/component: worker
+spec:
+  replicas: {{ .Values.workerReplicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Chart.Name }}
+      app.kubernetes.io/component: worker
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Chart.Name }}
+        app.kubernetes.io/component: worker
+    spec:
+      serviceAccountName: {{ .Release.Name }}-worker
+      containers:
+        - name: worker
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["node", "./build/worker/index.js"]
+          envFrom:
+            - secretRef:
+                name: {{ .Release.Name }}-env
+          env:
+            - name: CV_DB_PATH
+              value: /db/customer-vision.sqlite
+            - name: OTEL_SERVICE_NAME
+              value: customer-vision-worker
+            # Explicit rather than left to the code default: the lease is what
+            # stops two replicas running the loops at once, and sharing a name
+            # with another app would make both alternate leadership silently.
+            - name: LEASE_NAME
+              value: {{ .Release.Name }}-worker
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - name: data
+              mountPath: /db
+          resources:
+            {{- toYaml .Values.worker.resources | nindent 12 }}
+          # Liveness: heartbeat file refreshed every 10s by worker main loop
+          # If the loop hangs for >60s, restart the pod
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - "test $(($(date +%s) - $(stat -c %Y /tmp/customer-vision-worker.heartbeat 2>/dev/null || echo 0))) -lt 60"
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          # Startup: give up to 2 minutes for migrations to complete
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - "test -f /tmp/customer-vision-worker.heartbeat"
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 12
+      volumes:
+        - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-data
+          {{- else }}
+          emptyDir: {}
+          {{- end }}

--- a/charts/customer-vision/values.yaml
+++ b/charts/customer-vision/values.yaml
@@ -1,0 +1,47 @@
+replicaCount: 1
+workerReplicaCount: 1
+
+image:
+  repository: ghcr.io/fredericrous/customer-vision
+  tag: latest
+  pullPolicy: IfNotPresent
+
+web:
+  port: 3000
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+
+worker:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+persistence:
+  enabled: true
+  size: 1Gi
+  storageClass: ""
+
+env:
+  SESSION_SECRET: ""
+  OIDC_ISSUER_URL: ""
+  OIDC_CLIENT_ID: ""
+  OIDC_CLIENT_SECRET: ""
+  OIDC_REDIRECT_URI: ""
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://alloy.monitoring.svc.cluster.local.:4318"
+  GTM_BASE_URL: "http://gtm-agent.gtm-agent.svc.cluster.local:8080"
+  JMAP_BASE_URL: "http://stalwart.stalwart.svc.cluster.local:8080"
+
+ingress:
+  enabled: false
+  className: ""
+  host: crm.daddyshome.fr
+  tls: false


### PR DESCRIPTION
Adds the `customer-vision` chart (web + leader-elected worker: gtm sync, JMAP reply poller, status writeback to gtm-agent).

Added **by hand** rather than by customer-vision's `update-helm-chart.yaml`: that repo was created today and has no `CHARTS_REPO_TOKEN` yet, so the trigger failed. This is the same content the workflow would have synced — the token still wants setting so later releases are automatic.

`appVersion` is 0.1.0. The source release job left it at the scaffold's 0.0.1 because its bump step early-exits when `version` already matches, without also checking `appVersion` — only reachable on a first release, where the scaffold had set `version` ahead of the tag.

Image `ghcr.io/fredericrous/customer-vision:0.1.0` is already published (buildah, on the new ARC runners).

`helm lint` clean, `helm template` renders, `kubeconform` strict passes on the output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)