### PR TITLE
chore: update customer-vision to 0.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ helm repo update
 
 | Chart | Version | App Version | Description |
 |-------|---------|-------------|-------------|
-| [customer-vision](charts/customer-vision/) | 0.1.0 | 0.1.0 | CRM for the intelligent-enterprise suite — accounts, contacts, deals |
+| [customer-vision](charts/customer-vision/) | 0.1.1 | 0.1.1 | CRM for the intelligent-enterprise suite — accounts, contacts, deals |
 | [kb-vision](charts/kb-vision/) | 0.12.6 | 0.12.6 | Knowledge Base for Homelab |
 | [duro-app](charts/duro-app/) | 1.50.52 | 1.50.52 | A household management dashboard with invite system |
 | [cluster-vision](charts/cluster-vision/) | 0.22.0 | 0.22.0 | Auto-generated infrastructure diagrams from live Kubernetes state |

--- a/charts/customer-vision/Chart.yaml
+++ b/charts/customer-vision/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: customer-vision
 description: CRM for the intelligent-enterprise suite — accounts, contacts, deals
 type: application
-version: 0.1.0
-appVersion: 0.1.0
+version: 0.1.1
+appVersion: 0.1.1


### PR DESCRIPTION
Serialised migrations and repaired in-cluster leader election — both defects exposed by the first real deployment.

- **Migrations raced.** web and worker start together and both migrate; each read an empty `_migrations`, each ran the whole set, and the loser died on a PK violation. The crash self-healed; the DDL running **twice** is the real problem. Now wrapped in a transaction taking `pg_advisory_xact_lock` (transaction-scoped, because pooled connections make session-scoped unlocks unreliable).
- **Leader election never worked in-cluster.** Global `fetch` could not verify the cluster CA, and the error was swallowed by a catch that set `_isLeader = true` — so every replica believed it led and no Lease existed. Switched to `node:https` with the ServiceAccount CA; a failed renew now stands down instead of conferring leadership.

Image `0.1.1` published. `helm lint` clean.

Note: the `ct install` check will fail on the anonymous pull of a private image, as it does for ticket-vision and kb-vision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)