### PR TITLE
chore: update customer-vision to 0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ helm repo update
 
 | Chart | Version | App Version | Description |
 |-------|---------|-------------|-------------|
-| [customer-vision](charts/customer-vision/) | 0.1.1 | 0.1.1 | CRM for the intelligent-enterprise suite — accounts, contacts, deals |
+| [customer-vision](charts/customer-vision/) | 0.1.2 | 0.1.2 | CRM for the intelligent-enterprise suite — accounts, contacts, deals |
 | [kb-vision](charts/kb-vision/) | 0.12.6 | 0.12.6 | Knowledge Base for Homelab |
 | [duro-app](charts/duro-app/) | 1.50.52 | 1.50.52 | A household management dashboard with invite system |
 | [cluster-vision](charts/cluster-vision/) | 0.22.0 | 0.22.0 | Auto-generated infrastructure diagrams from live Kubernetes state |

--- a/charts/customer-vision/Chart.yaml
+++ b/charts/customer-vision/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: customer-vision
 description: CRM for the intelligent-enterprise suite — accounts, contacts, deals
 type: application
-version: 0.1.1
-appVersion: 0.1.1
+version: 0.1.2
+appVersion: 0.1.2


### PR DESCRIPTION
Lease timestamps as MicroTime.

`acquireTime`/`renewTime` are `v1.MicroTime`, which Go parses with exactly **six** fractional digits; `toISOString()` emits three, so every lease write came back 400 and no Lease was ever created. 0.1.1 fixed the TLS failure that had been masking this one.

Also widened the vitest include to `worker/**` — until now nothing under it was collected at all.

Verified against the live apiserver: the same POST that returned 400 returns 201 with the padded value.

Note: `ct install` will fail on the anonymous pull of a private image, as for ticket-vision and kb-vision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)